### PR TITLE
Add wrapper exclusion support for link warnings

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "webberzone/webberzone-link-warnings",
     "description": "Enhances accessibility by warning users when links open in new windows or navigate to external sites.",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "type": "wordpress-plugin",
     "keywords": [
         "accessibility",

--- a/includes/class-content-processor.php
+++ b/includes/class-content-processor.php
@@ -74,9 +74,29 @@ class Content_Processor {
 		$this->settings = wzlw_get_settings();
 
 		// Use WP_HTML_Tag_Processor to parse links.
-		$processor = new \WP_HTML_Tag_Processor( $content );
+		$processor  = new \WP_HTML_Tag_Processor( $content );
+		$skip_depth = 0;
 
-		while ( $processor->next_tag( array( 'tag_name' => 'a' ) ) ) {
+		while ( $processor->next_tag() ) {
+			if ( $skip_depth > 0 ) {
+				$skip_depth += $this->get_skip_depth_delta( $processor );
+
+				if ( 0 >= $skip_depth ) {
+					$skip_depth = 0;
+				}
+
+				continue;
+			}
+
+			if ( $this->is_skip_wrapper_tag( $processor ) ) {
+				$skip_depth = 1;
+				continue;
+			}
+
+			if ( 'A' !== $processor->get_tag() ) {
+				continue;
+			}
+
 			$href   = $processor->get_attribute( 'href' );
 			$target = $processor->get_attribute( 'target' );
 
@@ -146,6 +166,82 @@ class Content_Processor {
 		);
 
 		return $content;
+	}
+
+	/**
+	 * Check if the current tag starts a wrapper that should skip processing.
+	 *
+	 * @since 1.1.0
+	 * @param \WP_HTML_Tag_Processor $processor HTML tag processor instance.
+	 * @return bool True if the tag is a skip wrapper.
+	 */
+	private function is_skip_wrapper_tag( \WP_HTML_Tag_Processor $processor ) {
+		if ( $processor->is_tag_closer() ) {
+			return false;
+		}
+
+		$class_name = $processor->get_attribute( 'class' );
+
+		if ( ! is_string( $class_name ) || '' === $class_name ) {
+			return false;
+		}
+
+		return $this->has_skip_wrapper_class( $class_name );
+	}
+
+	/**
+	 * Check if a class attribute contains the skip wrapper class.
+	 *
+	 * @since 1.1.0
+	 * @param string $class_name Class attribute value.
+	 * @return bool True if the class is present.
+	 */
+	private function has_skip_wrapper_class( $class_name ) {
+		$classes = preg_split( '/\s+/', trim( $class_name ) );
+
+		if ( ! is_array( $classes ) ) {
+			return false;
+		}
+
+		return in_array( 'wzlw-no-icon-wrapper', $classes, true );
+	}
+
+	/**
+	 * Get the nesting delta for skipped wrapper traversal.
+	 *
+	 * @since 1.1.0
+	 * @param \WP_HTML_Tag_Processor $processor HTML tag processor instance.
+	 * @return int Nesting delta.
+	 */
+	private function get_skip_depth_delta( \WP_HTML_Tag_Processor $processor ) {
+		if ( $processor->is_tag_closer() ) {
+			return -1;
+		}
+
+		if ( $this->tag_is_void( $processor->get_tag() ) ) {
+			return 0;
+		}
+
+		return 1;
+	}
+
+	/**
+	 * Check whether a tag is a void element.
+	 *
+	 * @since 1.1.0
+	 * @param string|null $tag_name Tag name.
+	 * @return bool True if the tag is a void element.
+	 */
+	private function tag_is_void( $tag_name ) {
+		if ( ! is_string( $tag_name ) || '' === $tag_name ) {
+			return false;
+		}
+
+		return in_array(
+			strtoupper( $tag_name ),
+			array( 'AREA', 'BASE', 'BR', 'COL', 'EMBED', 'HR', 'IMG', 'INPUT', 'LINK', 'META', 'SOURCE', 'TRACK', 'WBR' ),
+			true
+		);
 	}
 
 	/**

--- a/package.json
+++ b/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@webberzone/webberzone-link-warnings",
+  "version": "1.1.0",
+  "description": "Enhances accessibility by warning users when links open in new windows or navigate to external sites.",
+  "author": "WebberZone",
+  "license": "GPL-2.0-or-later",
+  "main": "index.js",
+  "scripts": {
+    "build:assets": "node build-assets.js",
+    "check-engines": "wp-scripts check-engines",
+    "packages-update": "wp-scripts packages-update",
+    "zip": "wp-scripts plugin-zip"
+  },
+  "files": [
+    "includes",
+    "languages",
+    "README.md",
+    "webberzone-link-warnings.php",
+    "index.php",
+    "uninstall.php",
+    "changelog.txt",
+    "readme.txt",
+    "wpml-config.xml"
+  ],
+  "devDependencies": {
+    "@wordpress/prettier-config": "^4.41.0",
+    "@wordpress/scripts": "^31.6.0",
+    "clean-css-cli": "^5.6.3",
+    "rtlcss": "^4.3.0",
+    "terser": "^5.46.0"
+  }
+}

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Donate link: https://ajaydsouza.com/donate/
 Requires at least: 6.6
 Tested up to: 6.9
 Requires PHP: 7.4
-Stable tag: 1.0.0
+Stable tag: 1.1.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -179,10 +179,16 @@ Your links return to their original state. The plugin doesn't modify your conten
 
 == Changelog ==
 
+= 1.1.0 =
+* Add support for excluding links inside wrappers with the `wzlw-no-icon-wrapper` class.
+
 = 1.0.0 =
 * Initial release.
 
 == Upgrade Notice ==
+
+= 1.1.0 =
+Adds support for excluding links inside wrapper elements using the `wzlw-no-icon-wrapper` class.
 
 = 1.0.0 =
 Initial release.

--- a/webberzone-link-warnings.php
+++ b/webberzone-link-warnings.php
@@ -14,7 +14,7 @@
  * Plugin Name: WebberZone Link Warnings
  * Plugin URI: https://webberzone.com/plugins/webberzone-link-warnings/
  * Description: Enhances accessibility by warning users when links open in new windows or navigate to external sites.
- * Version: 1.0.0
+ * Version: 1.1.0
  * Author: WebberZone
  * Author URI: https://webberzone.com/
  * License: GPL-2.0+
@@ -31,7 +31,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 // Define plugin constants.
-define( 'WZLW_VERSION', '1.0.0' );
+define( 'WZLW_VERSION', '1.1.0' );
 define( 'WZLW_PLUGIN_FILE', __FILE__ );
 define( 'WZLW_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'WZLW_PLUGIN_URL', plugin_dir_url( __FILE__ ) );


### PR DESCRIPTION
## Summary

- add support for excluding links inside wrapper elements with the `wzlw-no-icon-wrapper` class
- bump plugin version metadata to `1.1.0`
- update `readme.txt` changelog and upgrade notice for `1.1.0`

## Testing

- php -l includes/class-content-processor.php

Closes #1